### PR TITLE
Add Boozer quasi-isodynamic documentation

### DIFF
--- a/docs/source/example_quasiisodynamic.rst
+++ b/docs/source/example_quasiisodynamic.rst
@@ -1,0 +1,148 @@
+.. _example_quasiisodynamic:
+
+Optimizing for quasi-isodynamicity on a Boozer surface
+======================================================
+
+This tutorial introduces the milestone-1 quasi-isodynamic Boozer-surface
+objective implemented in :obj:`simsopt.geo.NonQuasiIsodynamicRatio` and the
+example script :simsopt_file:`examples/2_Intermediate/boozerQI.py`.
+
+The workflow is intentionally close to :simsopt_file:`examples/2_Intermediate/boozerQA.py`:
+
+- a coil-generated Biot-Savart field is used,
+- a single :obj:`~simsopt.geo.BoozerSurface` is computed near the magnetic axis,
+- the coils are optimized on that surface,
+- penalty terms keep the rotational transform, major radius, and total coil length near their initial values.
+
+The key difference is the symmetry objective. Instead of minimizing a
+quasi-axisymmetric ratio based on averaging :math:`|B|` along one coordinate,
+the QI objective compares each sampled magnetic well against a shuffled target
+that equalizes weighted bounce distances across field lines.
+
+
+Objective definition
+--------------------
+
+For one Boozer surface, let
+
+.. math::
+
+   \phi_B = 2\pi\varphi,
+   \qquad
+   \theta_B = 2\pi\theta,
+
+and sample one field period
+
+.. math::
+
+   \phi_B \in [\phi_{\min}, \phi_{\min} + 2\pi / n_{fp}].
+
+For field-line labels
+
+.. math::
+
+   \alpha_j = 2\pi j / n_{\alpha},
+
+the line is sampled at
+
+.. math::
+
+   \theta_B(\phi_B; \alpha_j) = \alpha_j + \iota (\phi_B - \phi_{\min}),
+
+and the field strength is
+
+.. math::
+
+   B_j(\phi_B) = |B(\phi_B, \theta_B(\phi_B; \alpha_j))|.
+
+The sampled field strengths are normalized globally on the auxiliary Boozer
+surface,
+
+.. math::
+
+   \widehat{B}_j(\phi_B) = \frac{B_j(\phi_B) - B_{\min}}{\max(B_{\max} - B_{\min}, \varepsilon_B)}.
+
+For each field line, the magnetic well is split at its minimum, transformed with
+the legacy left and right squash rules, stretched using cosine-power profiles,
+and converted into bounce branches using the same crossing logic as the legacy
+``GetBranches`` routine from the old omnigenity optimization code.
+
+The branch locations are then shifted so the weighted average bounce distance is
+shared across field lines, producing a shuffled target
+:math:`\widehat{B}_{QI,j}`. The residual samples are
+
+.. math::
+
+   r_{jm} = \frac{\widehat{B}_{QI,j}(\phi_m) - \widehat{B}_j(\phi_m)}{\sqrt{n_{\alpha} n_{\phi,\mathrm{out}}}},
+
+and the milestone-1 scalar objective is
+
+.. math::
+
+   J_{QI} = \sum_{j,m} r_{jm}^2.
+
+
+How the example is structured
+-----------------------------
+
+The example performs the following sequence:
+
+1. Load the NCSX coil set from :obj:`simsopt.configs.get_data`.
+2. Build an initial :obj:`~simsopt.geo.SurfaceXYZTensorFourier` surface.
+3. Solve for a Boozer surface using :obj:`~simsopt.geo.BoozerSurface`.
+4. Build a total objective from:
+
+   - :obj:`~simsopt.geo.NonQuasiIsodynamicRatio`
+   - :obj:`~simsopt.geo.Iotas`
+   - :obj:`~simsopt.geo.MajorRadius`
+   - total coil-length penalties.
+
+5. Run a BFGS optimization.
+
+In normal interactive use the script writes VTK files for the initial and final
+coils and surfaces. For testing or quick checks, runtime can be reduced with
+environment variables.
+
+
+Runtime controls
+----------------
+
+The example supports these environment variables:
+
+- ``SIMSOPT_BOOZER_QI_MPOL`` and ``SIMSOPT_BOOZER_QI_NTOR`` to reduce the Boozer-surface representation.
+- ``SIMSOPT_BOOZER_QI_SDIM`` to reduce the auxiliary QI quadrature surface.
+- ``SIMSOPT_BOOZER_QI_NPHI``, ``SIMSOPT_BOOZER_QI_NALPHA``, ``SIMSOPT_BOOZER_QI_NBJ``, and ``SIMSOPT_BOOZER_QI_NPHI_OUT`` to reduce the QI residual resolution.
+- ``SIMSOPT_BOOZER_QI_MAXITER`` to limit optimization iterations.
+- ``SIMSOPT_BOOZER_QI_SKIP_TAYLOR=1`` to skip the expensive Taylor-test block.
+- ``SIMSOPT_BOOZER_QI_WRITE_VTK=0`` to suppress output files.
+- ``SIMSOPT_BOOZER_QI_OUT_DIR`` to choose an output directory.
+- ``SIMSOPT_BOOZER_QI_VMEC`` to initialize the starting surface from a VMEC boundary shape.
+
+An example reduced-runtime invocation is::
+
+   SIMSOPT_BOOZER_QI_WRITE_VTK=0 \
+   SIMSOPT_BOOZER_QI_SKIP_TAYLOR=1 \
+   SIMSOPT_BOOZER_QI_MAXITER=0 \
+   SIMSOPT_BOOZER_QI_MPOL=3 \
+   SIMSOPT_BOOZER_QI_NTOR=3 \
+   SIMSOPT_BOOZER_QI_SDIM=6 \
+   SIMSOPT_BOOZER_QI_NPHI=21 \
+   SIMSOPT_BOOZER_QI_NALPHA=3 \
+   SIMSOPT_BOOZER_QI_NBJ=5 \
+   SIMSOPT_BOOZER_QI_NPHI_OUT=21 \
+   python examples/2_Intermediate/boozerQI.py
+
+
+Current limitations
+-------------------
+
+This milestone-1 implementation is intentionally narrow:
+
+- It operates on a single Boozer surface in a coil-generated Biot-Savart field.
+- It does not use ``booz_xform`` or a VMEC quasisymmetry objective.
+- The current derivative of :obj:`~simsopt.geo.NonQuasiIsodynamicRatio` is a finite-difference coil gradient, which is suitable for smoke tests and experimentation but slower than an adjoint implementation.
+- The optional VMEC initializer is only a geometry initializer for the starting surface. The magnetic field still comes from the coils, so the VMEC configuration must have the same number of field periods as the coil set.
+
+These limitations keep the new objective close to the existing Boozer-surface
+optimization workflow while preserving parity with the legacy single-surface QI
+residual.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,10 +82,11 @@ optimization.  Others include `STELLOPT
 .. toctree::
    :maxdepth: 3
    :caption: Tutorials
-   
+
    example_vmec
    example_vmec_only
    example_quasisymmetry
+   example_quasiisodynamic
    example_islands
    example_coils
    example_single_stage

--- a/src/simsopt/configs/zoo.py
+++ b/src/simsopt/configs/zoo.py
@@ -583,33 +583,36 @@ def get_w7x_data(Nt_coils=48, Nt_ma=10, ppp=2):
 
 def download_ID_from_QUASR_database(ID, return_style="simsopt-style", verbose=True, use_cache=True): 
     """
-    Download a configuration from the QUASR database.  Downloaded configuration files are cached in 
-    [SIMSOPT_INSTALL_DIR]/src/simsopt/configs/QUASR_cache/
-    The cache is pruned to keep 100 files (~10MB) to avoid excessive disk usage.
+    Download a configuration from the QUASR database.
 
-    Args:
-        ID (int): the ID of the configuration to download (leading zeros removed).  
-                  A pandas dataframe containing metadata on the devices, including all
-                  valid ID numbers is located at: https://quasr.flatironinstitute.org/QUASR.pkl
-                  The database is navigatable online at https://quasr.flatironinstitute.org/
-                  Alternatively, you can download the latest full set of devices from https://zenodo.org/doi/10.5281/zenodo.10050655
-        
-        return_style (str): How to return the information either: 
-                             ``"quasr-style"``: two-element tuple containing ([SurfaceXYXTensorFourier], # surfaces
-                                                                              [Coil,]                    # all coils
-                                                                              )
-                             ``"simsopt-style"``: five-element tuple containing ([base_curves ],         # curves of coils in first field/half period
-                                                                                 [base_currents, ],      # currents of these coils
-                                                                                 [nfp, ],                # number of field periods
-                                                                                 [coils, ]               # all coils
-                                                                                )
+    Downloaded configuration files are cached in
+    ``[SIMSOPT_INSTALL_DIR]/src/simsopt/configs/QUASR_cache/``. The cache is
+    pruned to keep 100 files, roughly 10 MB, to avoid excessive disk usage.
 
-        verbose (boolean): if true, additional caching and downloading status messages are printed, otherwise they are not.
+    Parameters
+    ----------
+    ID : int
+        ID of the configuration to download, with leading zeros removed.
+        Metadata containing valid IDs is available at
+        ``https://quasr.flatironinstitute.org/QUASR.pkl``. The database can be
+        browsed at ``https://quasr.flatironinstitute.org/``. A full archive is
+        also available at ``https://zenodo.org/doi/10.5281/zenodo.10050655``.
+    return_style : str, optional
+        Return format. ``"quasr-style"`` returns ``(surfaces, coils)``.
+        ``"simsopt-style"`` returns
+        ``(base_curves, base_currents, nfp, coils)``.
+    verbose : bool, optional
+        If ``True``, print cache and download status messages.
+    use_cache : bool, optional
+        If ``True``, save the downloaded file to disk. The cache is stored in
+        the simsopt installation directory if writable, otherwise in the
+        current working directory. If ``False``, no caching is performed.
 
-        use_cache (True): if true, the downloaded file will be saved to disk. The location will the in the simsopt installation directory if writeable, otherwise in the current working directory. If false, no caching is performed.
-
-        returns: 
-            a list containing: [list of simsopt.geo.Coil objects, list of simsopt.field.Current objects]
+    Returns
+    -------
+    tuple
+        Either ``(surfaces, coils)`` or ``(base_curves, base_currents, nfp,
+        coils)``, depending on ``return_style``.
     """
     if return_style not in ['simsopt-style', 'quasr-style']:
         raise ValueError(f"invalid return_style: {return_style}, must be either simsopt-style or quasr-style")

--- a/src/simsopt/field/force.py
+++ b/src/simsopt/field/force.py
@@ -1204,56 +1204,57 @@ def lp_force_pure(
 
 class LpCurveForce(Optimizable):
     r"""
-    Optimizable class to minimize the total Lp-Lorentz force density (force per unit length) integrated. 
-    Force density on a coil is computed on each coil in a set of m target coils, using the self-force from
-    the coil itself, the force from the other m - 1 target coils and the force from a set of m' source coils.
-    If source_coils_coarse and target_coils have coils in common, they are removed during initialization of this class,
-    to avoid double counting forces. A typical use case has the target_coils as the unique base_coils 
-    in a stellarator optimization, and source_coils_coarse are all the coils after applying symmetries. 
-    Typical initialization is LpCurveForce(base_coils, coils).
+    Optimizable class that minimizes an :math:`L_p` Lorentz-force density objective.
+
+    Force density is evaluated on each coil in a target set using three possible
+    contributions: self-force, force from the other target coils, and force from
+    one or two source-coil sets. If ``source_coils_coarse`` overlaps with
+    ``target_coils``, the overlapping coils are removed during initialization to
+    avoid double counting.
+
+    A typical use case sets ``target_coils`` to the unique base coils in a
+    stellarator optimization and uses all symmetry-expanded coils as
+    ``source_coils_coarse``.
 
     The objective function is
 
     .. math::
-        J = \frac{1}{p}\sum_i\frac{1}{L_i}\left(\int \text{max}(|d\vec{F}/d\ell_i| - F_0 , 0)^p d\ell_i\right)
 
-    where :math:`\frac{d\vec{F}_i}{d\ell_i}` is the Lorentz force per unit length, 
-    in units of MN/m, where MN = meganewtons. The units of the objective function are therefore (MN/m)^p.
-    :math:`d\ell_i` is the arclength along the ith coil,
-    :math:`L_i` is the total coil length,
-    and :math:`F_0 ` is a threshold force at the ith coil.
+        J = \frac{1}{p}\sum_i\frac{1}{L_i}\left(\int \max\left(|d\vec{F}/d\ell_i| - F_0, 0\right)^p d\ell_i\right)
 
-    This class assumes there are two (or three) distinct lists of coils,
-    which may have different finite-build parameters and/or different numbers of quadrature points. 
-    In order to avoid buildup of optimizable 
-    dependencies, it directly computes the BiotSavart law terms, instead of relying on the existing
-    C++ code that computes BiotSavart related terms. Within each list of coils, 
-    all coils must have the same number of quadrature points. The source_coils_coarse and source_coils_fine lists
-    allows one to optimize e.g. the torque on target_coils from a set of dipole coils 
-    (with barely any quadrature points) and a set of TF coils (with many quadrature points).
+    Here :math:`d\vec{F}_i / d\ell_i` is the Lorentz force per unit length in
+    units of MN/m, :math:`d\ell_i` is arclength along coil :math:`i`,
+    :math:`L_i` is the total coil length, and :math:`F_0` is the threshold
+    force for that coil. The objective therefore has units of
+    :math:`(\mathrm{MN}/\mathrm{m})^p`.
 
-    Args:
-        target_coils (list of RegularizedCoil, shape (m,)): 
-            List of coils on which the LpCurveForce is computed.
-        source_coils_coarse (list of Coil or RegularizedCoil, shape (m',)): 
-            Coarse-resolution source coils that provide forces on the target_coils.
-            Forces are not computed on the source_coils.
-        source_coils_fine (list of Coil or RegularizedCoil, optional): 
-            Fine-resolution source coils, used in addition to coarse. Default: []. This functionality
-            is provided for when there are two sets of source coils with very different numbers of
-            quadrature points. This occurs e.g. when optimizing TF coils and dipole coils.
-        p (float): Power of the objective function.
-        threshold (float): Threshold force per unit length in units of MN/m (meganewtons per meter).
-        downsample (int): 
-            Factor by which to downsample the quadrature points 
-            by skipping through the array by a factor of ``downsample``,
-            e.g. curve.gamma()[::downsample, :]. 
-            Setting this parameter to a value larger than 1 will speed up the calculation,
-            which may be useful if the set of coils is large, though it may introduce
-            inaccuracy if ``downsample`` is set too large, or not a multiple of the 
-            total number of quadrature points (since this will produce a nonuniform set of points). 
-            This parameter is used to speed up expensive calculations during optimization, 
-            while retaining higher accuracy for the other objectives. 
+    This class assumes there are two or three distinct coil lists, possibly with
+    different finite-build parameters and different quadrature resolutions.
+    To avoid a large optimizable-dependency graph, it computes the Biot-Savart
+    contributions directly rather than relying on the existing C++
+    :class:`BiotSavart` implementation. Within each list, all coils must have
+    the same number of quadrature points.
+
+    Parameters
+    ----------
+    target_coils : list of RegularizedCoil
+        Coils on which the force objective is evaluated.
+    source_coils_coarse : list of Coil or RegularizedCoil
+        Coarse-resolution source coils that contribute force to the target
+        coils. Forces are not evaluated on the source coils themselves.
+    source_coils_fine : list of Coil or RegularizedCoil, optional
+        Additional fine-resolution source coils. This is useful when combining
+        source coils with very different quadrature counts, such as TF coils and
+        dipole coils.
+    p : float, optional
+        Power used in the :math:`L_p` objective.
+    threshold : float, optional
+        Threshold force per unit length in MN/m.
+    downsample : int, optional
+        Downsampling factor used to subsample the quadrature points, for
+        example ``curve.gamma()[::downsample, :]``. Values larger than one can
+        speed up optimization but may reduce accuracy if the factor is too
+        large or does not divide the original quadrature count evenly.
     """
 
     def __init__(self, target_coils, source_coils_coarse, source_coils_fine=None, p: float = 2.0, threshold: float = 0.0, downsample: int = 1):


### PR DESCRIPTION
## Summary
- add the quasi-isodynamic user guide page and wire it into the docs index
- document the milestone-1 Boozer-surface workflow and runtime controls for boozerQI.py
- include docstring cleanup needed to unblock the new documentation path

## Validation
- /Users/rogerio/base_env/bin/python -m pytest tests/geo/test_boozer_qi_math.py tests/geo/test_surface_objectives.py -k "boozer_qi_math or nonQIratio or boozer_qi_example_reduced_runtime" -q

## Notes
- A full strict Sphinx build still surfaces inherited repo-wide warnings outside this stack.
